### PR TITLE
Added nginx annotation for /apis redirection

### DIFF
--- a/K8s-deployment/Charts/auth-server/values.yaml
+++ b/K8s-deployment/Charts/auth-server/values.yaml
@@ -1759,7 +1759,9 @@ ingress:
     nginx.ingress.kubernetes.io/global-rate-limit-window: 1s,
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1",
     nginx.ingress.kubernetes.io/limit-connections: "150",
-    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/limit-rps: "100",
+    nginx.ingress.kubernetes.io/app-root: "/apis"
+
   }
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`

--- a/K8s-deployment/Charts/catalogue/values.yaml
+++ b/K8s-deployment/Charts/catalogue/values.yaml
@@ -1752,7 +1752,9 @@ ingress:
     nginx.ingress.kubernetes.io/global-rate-limit-window: 1s,
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1",
     nginx.ingress.kubernetes.io/limit-connections: "150",
-    nginx.ingress.kubernetes.io/limit-rps: "150"
+    nginx.ingress.kubernetes.io/limit-rps: "150",
+    nginx.ingress.kubernetes.io/app-root: "/apis"
+
   }
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`

--- a/K8s-deployment/Charts/data-ingestion/values.yaml
+++ b/K8s-deployment/Charts/data-ingestion/values.yaml
@@ -1091,7 +1091,8 @@ ingress:
     nginx.ingress.kubernetes.io/global-rate-limit-window: 1s,
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1",
     nginx.ingress.kubernetes.io/limit-connections: "100",
-    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/limit-rps: "100",
+    nginx.ingress.kubernetes.io/app-root: "/apis"
   }
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`

--- a/K8s-deployment/Charts/file-server/values.yaml
+++ b/K8s-deployment/Charts/file-server/values.yaml
@@ -1894,7 +1894,8 @@ ingress:
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1",
     nginx.ingress.kubernetes.io/limit-connections: "100",
     nginx.ingress.kubernetes.io/limit-rps: "100",
-    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
+    nginx.ingress.kubernetes.io/proxy-body-size: 1024m,
+    nginx.ingress.kubernetes.io/app-root: "/apis"
   }
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`

--- a/K8s-deployment/Charts/gis-interface/values.yaml
+++ b/K8s-deployment/Charts/gis-interface/values.yaml
@@ -1799,7 +1799,8 @@ ingress:
     nginx.ingress.kubernetes.io/global-rate-limit-window: 1s,
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1",
     nginx.ingress.kubernetes.io/limit-connections: "100",
-    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/limit-rps: "100",
+    nginx.ingress.kubernetes.io/app-root: "/apis"
   }
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`

--- a/K8s-deployment/Charts/resource-server/values.yaml
+++ b/K8s-deployment/Charts/resource-server/values.yaml
@@ -2185,7 +2185,8 @@ ingress:
     nginx.ingress.kubernetes.io/global-rate-limit-window: 1s,
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1",
     nginx.ingress.kubernetes.io/limit-connections: "100",
-    nginx.ingress.kubernetes.io/limit-rps: "100"
+    nginx.ingress.kubernetes.io/limit-rps: "100",
+    nginx.ingress.kubernetes.io/app-root: "/apis"
   }
   ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
   ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`


### PR DESCRIPTION
Added nginx annotation- `nginx.ingress.kubernetes.io/app-root: "/apis"` to redirect requests at '/' to '/apis' endpoint for all apiServers.