### PR TITLE
Enabling tcp keepalives at servers 

### DIFF
--- a/Docker-Swarm-deployment/single-node/elk/database-stack.yml
+++ b/Docker-Swarm-deployment/single-node/elk/database-stack.yml
@@ -19,14 +19,9 @@ services:
         window: 10s
     networks:
       - overlay-net
-    environment:
-      - cluster.name=elastic-cluster
-      - node.name=es
-      - discovery.type=single-node
-      - action.auto_create_index=.*
-      - xpack.security.enabled=true
-      - xpack.security.audit.enabled=true
-      - xpack.security.transport.ssl.enabled=true
+    configs:
+      - source: elasticsearch-config
+        target:  /usr/share/elasticsearch/config/elasticsearch.yml
     logging:
       driver: "json-file"
       options:
@@ -128,6 +123,8 @@ volumes:
   logstash-volume:
 
 configs:
+  elasticsearch-config:
+    file: elasticsearch/elasticsearch.yml
   logstash-pipelines:
     file: logstash/settings/pipelines.yml
   logstash-settings:

--- a/Docker-Swarm-deployment/single-node/elk/elasticsearch/elasticsearch.yml
+++ b/Docker-Swarm-deployment/single-node/elk/elasticsearch/elasticsearch.yml
@@ -1,0 +1,12 @@
+network.tcp.keep_alive: true
+network.tcp.keep_idle: 120
+network.tcp.keep_interval : 120
+network.tcp.keep_count: 3
+network.host: 0.0.0.0
+cluster.name: elastic-cluster
+node.name: es
+discovery.type: single-node
+action.auto_create_index: +.*
+xpack.security.enabled: true
+xpack.security.audit.enabled: false
+xpack.security.transport.ssl.enabled: true

--- a/Docker-Swarm-deployment/single-node/postgres/postgres-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/postgres/postgres-stack.yaml
@@ -32,6 +32,9 @@ services:
     environment:
       - POSTGRESQL_PASSWORD_FILE=/opt/bitnami/postgresql/secrets/postgresql-password
       - POSTGRES_USER=postgres
+      - POSTGRESQL_TCP_KEEPALIVES_IDLE=120
+      - POSTGRESQL_TCP_KEEPALIVES_INTERVAL=120
+      - POSTGRESQL_TCP_KEEPALIVES_COUNT=3
     deploy:
       replicas: 1
       placement:

--- a/Docker-Swarm-deployment/single-node/redis/redis-rejson-stack.yml
+++ b/Docker-Swarm-deployment/single-node/redis/redis-rejson-stack.yml
@@ -18,6 +18,9 @@ services:
           volume:
             nocopy: false
           read_only: false
+      configs: 
+        - source: redis-conf
+          target: /opt/bitnami/redis/mounted-etc/overrides.conf
       networks:
         - overlay-net
       secrets:
@@ -45,6 +48,9 @@ networks:
 volumes:
   redis-persistence: 
 
+configs:
+  redis-conf:
+    file: redis.conf
 secrets:
   admin-password:
     file: secrets/passwords/admin-password

--- a/Docker-Swarm-deployment/single-node/redis/redis.conf
+++ b/Docker-Swarm-deployment/single-node/redis/redis.conf
@@ -1,0 +1,1 @@
+tcp-keepalive 120


### PR DESCRIPTION
- TCP keepalive at postgres
ref:  https://www.postgresql.org/docs/current/runtime-config-connection.html
- TCP keepalive at redis
 ref: https://raw.githubusercontent.com/antirez/redis/7.0/redis.conf
- TCP keepalive at elastic
 ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html