### PR TITLE
3.5.0: version update to 3.10.5

### DIFF
--- a/Docker-Swarm-deployment/single-node/databroker/databroker-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/databroker/databroker-stack.yaml
@@ -9,7 +9,7 @@ networks:
 
 services:
   rabbitmq:
-    image: rabbitmq:3.8.11-management # using ubuntu based images as its officially supported
+    image: rabbitmq:3.10.5-management # using ubuntu based images as its officially supported
     #setting the hostname, so that when same/new container restarts it uses the same directory to save i.e "/var/lib/rabbitmq/rabbit@hostname"
     hostname: rabbitmq
    # volume stores metadata of queues, excahnges and also persistent queue messages


### PR DESCRIPTION
- backport to 3.5.0 branch, as it works with 3.5.0 api servers