### PR TITLE
Docker software-update: Redis version update to 7.0.2-2.0.9

### DIFF
--- a/Docker-Swarm-deployment/single-node/redis/README.md
+++ b/Docker-Swarm-deployment/single-node/redis/README.md
@@ -16,7 +16,7 @@ secrets/
 ## Build the docker file
 This builds custom docker image on top of [bitnami docker redis](https://github.com/bitnami/bitnami-docker-redis) to include [rejson](https://oss.redis.com/redisjson/) module.
 ```sh
-docker build -t ghcr.io/datakaveri/redis-rejson:6.2.6-1.0.7 -f docker/redis-rejson/Dockerfile  docker/redis-rejson/ 
+docker build -t ghcr.io/datakaveri/redis-rejson:7.0.2-2.0.9 -f docker/redis-rejson/Dockerfile  docker/redis-rejson/ 
 ```
 ## Assign node labels
  The redis container is constrained to run on specifc node by adding node labels to only one of the nodes, refer [here](https://docs.docker.com/engine/swarm/services/#placement-constraints) for more info. This ensures the container is placed always to same node on restart and able to mount the same local docker volume.

--- a/Docker-Swarm-deployment/single-node/redis/docker/redis-rejson/Dockerfile
+++ b/Docker-Swarm-deployment/single-node/redis/docker/redis-rejson/Dockerfile
@@ -1,4 +1,4 @@
-FROM redislabs/rejson:1.0.7 as rejson
-FROM bitnami/redis:6.2.6 
+FROM redislabs/rejson:2.0.9 as rejson
+FROM bitnami/redis:7.0.2
 COPY --from=rejson /usr/lib/redis/modules/rejson.so /usr/local/lib/rejson.so
 WORKDIR /opt/bitnami

--- a/Docker-Swarm-deployment/single-node/redis/redis-rejson-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/redis/redis-rejson-stack.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
     redis-rejson:
-      image: ghcr.io/datakaveri/redis-rejson:6.2.6-1.0.7
+      image: ghcr.io/datakaveri/redis-rejson:7.0.2-2.0.9
       cap_drop:
         - ALL
       environment:
@@ -54,3 +54,4 @@ configs:
 secrets:
   admin-password:
     file: secrets/passwords/admin-password
+


### PR DESCRIPTION
Same changes as #154 rebased with datakaveri/master

Updates:
1. rejson from 1.0.7 to 2.0.9
2. redis from 6.2.6 to 7.0.2
3. image tag from  6.2.6-1.0.7  to 7.0.2-2.0.9
4. Updates in Stack files
5. Added redis.conf for tcpkeepalive