### PR TITLE
correct postgres init script

### DIFF
--- a/Docker-Swarm-deployment/single-node/postgres/init-scripts/db-user-creation.sh
+++ b/Docker-Swarm-deployment/single-node/postgres/init-scripts/db-user-creation.sh
@@ -12,12 +12,10 @@ auth_username=iudx_auth_user
 auth_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-auth-password)
 auth_db_name=iudx_auth
 
-PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$rs_db_name" <<-EOSQL
+PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+CREATE DATABASE $rs_db_name WITH ENCODING 'UTF8';
 CREATE ROLE $rs_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
 ALTER ROLE $rs_username WITH  ENCRYPTED PASSWORD '$rs_passwd';
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE  public.databroker TO $rs_username;
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE  public.file_server_token TO $rs_username;
-GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE  public.registercallback TO $rs_username;
 GRANT ALL ON SCHEMA public TO $rs_username;
 EOSQL
 


### PR DESCRIPTION
- include creation of db in swarm postgres init script
- rs schema script creation script also included creation of rs db https://github.com/datakaveri/iudx-deployment/pull/163/commits/7f809f21ad9ba5628f50c68acc19dfd79590a291 , hence this became a bug @pranavv0 @THARAK-RAM1 