### PR TITLE
4.0.0-new-rancher k8s upgrade

### DIFF
--- a/K8s-deployment/Charts/auth-server/charts/common/templates/_capabilities.tpl
+++ b/K8s-deployment/Charts/auth-server/charts/common/templates/_capabilities.tpl
@@ -116,6 +116,22 @@ Return the appropriate apiVersion for CRDs.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for Horizontal Pod Autoscaler.
+*/}}
+{{- define "common.capabilities.hpa.apiVersion" -}}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .context) -}}
+{{- if .beta2 -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- else -}}
+{{- print "autoscaling/v2" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Returns true if the used Helm version is 3.3+.
 A way to check the used Helm version was not introduced until version 3.3.0 with .Capabilities.HelmVersion, which contains an additional "{}}"  structure.
 This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVersion }} because checking for the key HelmVersion in <3.3 results in a "interface not found" error.

--- a/K8s-deployment/Charts/auth-server/templates/admin/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/admin/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.admin.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-admin

--- a/K8s-deployment/Charts/auth-server/templates/apd/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/apd/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apd.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-apd

--- a/K8s-deployment/Charts/auth-server/templates/apiServer/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/apiServer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiServer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-api-server

--- a/K8s-deployment/Charts/auth-server/templates/auditing/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/auditing/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.auditing.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-auditing

--- a/K8s-deployment/Charts/auth-server/templates/policy/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/policy/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.policy.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-policy

--- a/K8s-deployment/Charts/auth-server/templates/registration/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/registration/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.registration.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-registration

--- a/K8s-deployment/Charts/auth-server/templates/token/hpa.yaml
+++ b/K8s-deployment/Charts/auth-server/templates/token/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.token.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: aaa-token

--- a/K8s-deployment/Charts/catalogue/templates/apiServer/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/apiServer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiServer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-api-server

--- a/K8s-deployment/Charts/catalogue/templates/auditing/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/auditing/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.auditing.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-auditing

--- a/K8s-deployment/Charts/catalogue/templates/authenticator/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/authenticator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.authenticator.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-authenticator

--- a/K8s-deployment/Charts/catalogue/templates/database/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/database/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.database.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-database

--- a/K8s-deployment/Charts/catalogue/templates/databroker/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/databroker/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.databroker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-databroker

--- a/K8s-deployment/Charts/catalogue/templates/geocoding/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/geocoding/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.geocoding.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-geocoding

--- a/K8s-deployment/Charts/catalogue/templates/nlpSearch/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/nlpSearch/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nlpSearch.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-nlpsearch

--- a/K8s-deployment/Charts/catalogue/templates/profanity-checker-sdk/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/profanity-checker-sdk/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.profanityCheckSdk.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: profanity-check-sdk

--- a/K8s-deployment/Charts/catalogue/templates/rating/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/rating/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rating.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-rating

--- a/K8s-deployment/Charts/catalogue/templates/validator/hpa.yaml
+++ b/K8s-deployment/Charts/catalogue/templates/validator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.validator.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cat-validator

--- a/K8s-deployment/Charts/data-ingestion/templates/apiServer/hpa.yaml
+++ b/K8s-deployment/Charts/data-ingestion/templates/apiServer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiServer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: di-api-server

--- a/K8s-deployment/Charts/data-ingestion/templates/authenticator/hpa.yaml
+++ b/K8s-deployment/Charts/data-ingestion/templates/authenticator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.authenticator.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: di-authenticator

--- a/K8s-deployment/Charts/data-ingestion/templates/databroker/hpa.yaml
+++ b/K8s-deployment/Charts/data-ingestion/templates/databroker/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.databroker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: di-databroker

--- a/K8s-deployment/Charts/data-ingestion/templates/metering/hpa.yaml
+++ b/K8s-deployment/Charts/data-ingestion/templates/metering/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metering.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: di-metering

--- a/K8s-deployment/Charts/elk/elasticsearch/autoscale-cron.yml
+++ b/K8s-deployment/Charts/elk/elasticsearch/autoscale-cron.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: es-autoscaler-cron

--- a/K8s-deployment/Charts/file-server/example-aws-resource-values.yaml
+++ b/K8s-deployment/Charts/file-server/example-aws-resource-values.yaml
@@ -20,7 +20,7 @@ apiServer:
       cpu: 700m
       memory: 1.2Gi
   persistence:
-    storageClass: "ebs-storage-class"
+    storageClass: "ebs-csi-storage-class"
 
 ## authenticator resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/K8s-deployment/Charts/file-server/templates/apiServer/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/apiServer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiServer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-api-server

--- a/K8s-deployment/Charts/file-server/templates/auditing/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/auditing/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.auditing.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-auditing

--- a/K8s-deployment/Charts/file-server/templates/authenticator/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/authenticator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.authenticator.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-authenticator

--- a/K8s-deployment/Charts/file-server/templates/cache/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/cache/hpa.yaml
@@ -1,6 +1,6 @@
 
 {{- if .Values.cache.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-cache

--- a/K8s-deployment/Charts/file-server/templates/database/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/database/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.database.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-database 

--- a/K8s-deployment/Charts/file-server/templates/databroker/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/databroker/hpa.yaml
@@ -1,6 +1,6 @@
 
 {{- if .Values.databroker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-databroker

--- a/K8s-deployment/Charts/file-server/templates/postgres/hpa.yaml
+++ b/K8s-deployment/Charts/file-server/templates/postgres/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.postgres.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: fs-postgres

--- a/K8s-deployment/Charts/gis-interface/templates/apiServer/hpa.yaml
+++ b/K8s-deployment/Charts/gis-interface/templates/apiServer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiServer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: gis-api-server

--- a/K8s-deployment/Charts/gis-interface/templates/authenticator/hpa.yaml
+++ b/K8s-deployment/Charts/gis-interface/templates/authenticator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.authenticator.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: gis-authenticator

--- a/K8s-deployment/Charts/gis-interface/templates/cache/hpa.yaml
+++ b/K8s-deployment/Charts/gis-interface/templates/cache/hpa.yaml
@@ -1,6 +1,6 @@
 
 {{- if .Values.cache.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: gis-cache

--- a/K8s-deployment/Charts/gis-interface/templates/databroker/hpa.yaml
+++ b/K8s-deployment/Charts/gis-interface/templates/databroker/hpa.yaml
@@ -1,6 +1,6 @@
 
 {{- if .Values.databroker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: gis-databroker

--- a/K8s-deployment/Charts/gis-interface/templates/metering/hpa.yaml
+++ b/K8s-deployment/Charts/gis-interface/templates/metering/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metering.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: gis-metering

--- a/K8s-deployment/Charts/gis-interface/templates/postgres/hpa.yaml
+++ b/K8s-deployment/Charts/gis-interface/templates/postgres/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.postgres.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: gis-postgres

--- a/K8s-deployment/Charts/immudb/example-aws-resource-values.yaml
+++ b/K8s-deployment/Charts/immudb/example-aws-resource-values.yaml
@@ -9,7 +9,7 @@ immudb:
       cpu: 1500m
       memory: 7Gi
   persistence:
-    storageClass: "ebs-storage-class"
+    storageClass: "ebs-csi-storage-class"
     size: 80Gi
   install:
     createUsers: true

--- a/K8s-deployment/Charts/immudb/templates/hpa.yaml
+++ b/K8s-deployment/Charts/immudb/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.immudb.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: immudb

--- a/K8s-deployment/Charts/immudb/values.yaml
+++ b/K8s-deployment/Charts/immudb/values.yaml
@@ -415,7 +415,7 @@ immudb:
       registry: ghcr.io
       repository: datakaveri/immudb-config-generator
       tag: 1.4.0
-    ## @param immudb.install.hookEnv Hooks env to pass on.
+    ## @param immudb.install.hookEnvFile Hooks env File to pass on.
     hookEnvFile: "config-env"
 
 

--- a/K8s-deployment/Charts/latest-ingestion-pipeline/templates/cache/hpa.yaml
+++ b/K8s-deployment/Charts/latest-ingestion-pipeline/templates/cache/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cache.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: lip-cache

--- a/K8s-deployment/Charts/latest-ingestion-pipeline/templates/postgres/hpa.yaml
+++ b/K8s-deployment/Charts/latest-ingestion-pipeline/templates/postgres/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.postgres.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: lip-postgres

--- a/K8s-deployment/Charts/latest-ingestion-pipeline/templates/processor/hpa.yaml
+++ b/K8s-deployment/Charts/latest-ingestion-pipeline/templates/processor/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.processor.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: lip-processor

--- a/K8s-deployment/Charts/latest-ingestion-pipeline/templates/rabbitmq/hpa.yaml
+++ b/K8s-deployment/Charts/latest-ingestion-pipeline/templates/rabbitmq/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rabbitmq.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: lip-rabbitmq

--- a/K8s-deployment/Charts/latest-ingestion-pipeline/templates/redis/hpa.yaml
+++ b/K8s-deployment/Charts/latest-ingestion-pipeline/templates/redis/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.redis.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: lip-redis

--- a/K8s-deployment/Charts/postgresql/example-aws-resource-values.yaml
+++ b/K8s-deployment/Charts/postgresql/example-aws-resource-values.yaml
@@ -61,7 +61,7 @@ pgpool:
     node.kubernetes.io/instance-type: t3.medium
 
 persistence:
-  storageClass: "ebs-storage-class"
+  storageClass: "ebs-csi-storage-class"
   accessModes:
     - ReadWriteOnce
   size: 30Gi

--- a/K8s-deployment/Charts/redis/autoscale-cron.yaml
+++ b/K8s-deployment/Charts/redis/autoscale-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: redis-autoscaler-cron

--- a/K8s-deployment/Charts/redis/example-aws-resource-values.yaml
+++ b/K8s-deployment/Charts/redis/example-aws-resource-values.yaml
@@ -29,7 +29,7 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  storageClass: "ebs-storage-class"
+  storageClass: "ebs-csi-storage-class"
   ## @param persistence.accessModes Persistent Volume Access Modes
   ##
   accessModes:

--- a/K8s-deployment/Charts/resource-server/templates/apiServer/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/apiServer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apiServer.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-api-server

--- a/K8s-deployment/Charts/resource-server/templates/archivesDatabase/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/archivesDatabase/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.archivesDatabase.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-archives-database

--- a/K8s-deployment/Charts/resource-server/templates/async/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/async/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.async.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-async

--- a/K8s-deployment/Charts/resource-server/templates/authenticator/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/authenticator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.authenticator.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-authenticator

--- a/K8s-deployment/Charts/resource-server/templates/cache/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/cache/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cache.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-cache

--- a/K8s-deployment/Charts/resource-server/templates/databroker/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/databroker/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.databroker.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-databroker

--- a/K8s-deployment/Charts/resource-server/templates/latestDatabase/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/latestDatabase/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.latestDatabase.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-latest-database

--- a/K8s-deployment/Charts/resource-server/templates/metering/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/metering/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metering.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-metering

--- a/K8s-deployment/Charts/resource-server/templates/postgres/hpa.yaml
+++ b/K8s-deployment/Charts/resource-server/templates/postgres/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.postgres.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: rs-postgres

--- a/K8s-deployment/Charts/zookeeper/example-aws-resource-values.yaml
+++ b/K8s-deployment/Charts/zookeeper/example-aws-resource-values.yaml
@@ -30,7 +30,7 @@ persistence:
   enabled: true
   ## @param persistence.storageClass PVC Storage Class for ZooKeeper data volume
   ## if deploying in minikube, can use "standard"
-  storageClass: "ebs-storage-class"
+  storageClass: "ebs-csi-storage-class"
   ## @param persistence.accessModes PVC Access modes
   ##
   accessModes:

--- a/K8s-deployment/K8s-cluster/Rancher/configs/aws/cloud-init/K8s-master-etcd-cloud-init.sh
+++ b/K8s-deployment/K8s-cluster/Rancher/configs/aws/cloud-init/K8s-master-etcd-cloud-init.sh
@@ -11,7 +11,7 @@ EOF
   
 sysctl -p /etc/sysctl.d/90-kubelet.conf
 
-curl -sL https://releases.rancher.com/install-docker/19.03.sh | sh
+curl -sL https://releases.rancher.com/install-docker/20.10.sh | sh
 sudo usermod -aG docker ubuntu
 
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
@@ -20,4 +20,4 @@ PRIVATE_IP=$(curl -H "X-aws-ec2-metadata-token: ${TOKEN}" -s http://169.254.169.
 NODE_NAME=$(curl -H "X-aws-ec2-metadata-token: ${TOKEN}" -s http://169.254.169.254/latest/meta-data/local-hostname)
 K8S_ROLES="--etcd --controlplane"
 
-sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.5.9 --server https://<rancher_server_url> --token <token-value> --ca-checksum <ca_checksum_value-optional>  --internal-address $PRIVATE_IP $K8S_ROLES  --node-name $NODE_NAME
+sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.6.9 --server https://<rancher_server_url> --token <token-value> --ca-checksum <ca_checksum_value-optional>  --internal-address $PRIVATE_IP $K8S_ROLES  --node-name $NODE_NAME

--- a/K8s-deployment/K8s-cluster/Rancher/configs/aws/cloud-init/K8s-worker-cloud-init.sh
+++ b/K8s-deployment/K8s-cluster/Rancher/configs/aws/cloud-init/K8s-worker-cloud-init.sh
@@ -10,7 +10,7 @@ kernel.keys.root_maxbytes = 25000000
 EOF
 sysctl -p /etc/sysctl.d/90-kubelet.conf
 
-curl -sL https://releases.rancher.com/install-docker/19.03.sh | sh
+curl -sL https://releases.rancher.com/install-docker/20.10.sh | sh
 sudo usermod -aG docker ubuntu
 
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
@@ -19,5 +19,5 @@ PRIVATE_IP=$(curl -H "X-aws-ec2-metadata-token: ${TOKEN}" -s http://169.254.169.
 NODE_NAME=$(curl -H "X-aws-ec2-metadata-token: ${TOKEN}" -s http://169.254.169.254/latest/meta-data/local-hostname)
 K8S_ROLES="--worker"
 
-sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.5.9 --server https://<rancher_server_url> --token <token_value> --ca-checksum <ca_checksum_value-optional>  --internal-address $PRIVATE_IP $K8S_ROLES  --node-name $NODE_NAME
+sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.6.9 --server https://<rancher_server_url> --token <token_value> --ca-checksum <ca_checksum_value-optional>  --internal-address $PRIVATE_IP $K8S_ROLES  --node-name $NODE_NAME
 

--- a/K8s-deployment/K8s-cluster/Rancher/configs/azure/cloud-init/K8s-master-etcd-cloud-init.sh
+++ b/K8s-deployment/K8s-cluster/Rancher/configs/azure/cloud-init/K8s-master-etcd-cloud-init.sh
@@ -11,9 +11,9 @@ kernel.keys.root_maxbytes = 25000000
 EOF
 sysctl -p /etc/sysctl.d/90-kubelet.conf
 
-curl -sL https://releases.rancher.com/install-docker/19.03.sh | sh
+curl -sL https://releases.rancher.com/install-docker/20.10.sh | sh
 sudo usermod -aG docker ubuntu
 
 K8S_ROLES="--etcd --controlplane"
 
-sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:v2.5.5 --server https://<rancher_server_url> --token <token_value> --ca-checksum <ca_checksum_value> --address azpublic --internal-address azprivate ${K8S_ROLES}
+sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:v2.6.9 --server https://<rancher_server_url> --token <token_value>  --address azpublic --internal-address azprivate ${K8S_ROLES}

--- a/K8s-deployment/K8s-cluster/Rancher/configs/azure/cloud-init/K8s-worker-cloud-init.sh
+++ b/K8s-deployment/K8s-cluster/Rancher/configs/azure/cloud-init/K8s-worker-cloud-init.sh
@@ -11,10 +11,10 @@ kernel.keys.root_maxbytes = 25000000
 EOF
 sysctl -p /etc/sysctl.d/90-kubelet.conf
 
-curl -sL https://releases.rancher.com/install-docker/19.03.sh | sh
+curl -sL https://releases.rancher.com/install-docker/20.10.sh | sh
 sudo usermod -aG docker ubuntu
 
 K8S_ROLES="--worker"
 
-sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:v2.5.5 --server https://<rancher_server_url> --token <token_value> --ca-checksum <ca_checksum_value> --address azpublic --internal-address azprivate ${K8S_ROLES}
+sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run rancher/rancher-agent:v2.6.9 --server https://<rancher_server_url> --token <token_value>  --address azpublic --internal-address azprivate ${K8S_ROLES}
 

--- a/K8s-deployment/K8s-cluster/Rancher/docker-compose.yaml
+++ b/K8s-deployment/K8s-cluster/Rancher/docker-compose.yaml
@@ -2,7 +2,7 @@
 version: '2.4'
 services:
   rancher:
-    image: rancher/rancher:v2.5.9
+    image: rancher/rancher:v2.6.9
     restart: always
     privileged: true
     volumes:

--- a/K8s-deployment/K8s-cluster/addons/storage/azure/README.md
+++ b/K8s-deployment/K8s-cluster/addons/storage/azure/README.md
@@ -1,4 +1,5 @@
 # Azure storage
+## Deployment with AzureDisk intree drivers
 For in-tree azuredisk drivers, ```kubernetes.io/azure-disk``` provisioner can be used in the [azuredisk-storage-class.yaml](./azuredisk-storage-class.yaml).
 1. Following command will deploy the storageclass
 ``` kubectl apply -f azuredisk-storage-class.yaml```
@@ -42,13 +43,20 @@ kubectl create -f azure-cloud-provider.yaml
 2. Following command will deploy the storageclass
 ``` kubectl apply -f azuredisk-storage-class.yaml```
 
-# Deployment with AzureFile
-For in-tree azuredisk drivers, ```kubernetes.io/azure-file``` provisioner can be used in the [azurefile-storage-class.yaml](./azurefile-storage-class.yaml).
+## Deployment with AzureFile in-tree
+For in-tree azurefile drivers, ```kubernetes.io/azure-file``` provisioner can be used in the [azurefile-intree-storage-class.yaml](./azurefile-intree-storage-class.yaml).
 1. Following command will deploy the storageclass
-``` kubectl apply -f azurefile-storage-class.yaml```
+``` kubectl apply -f azurefile-intree-storage-class.yaml```
 
-## Deployment with AzureDisk csi drivers
-### Prerequisite
+## Deployment with AzureFile csi drivers
+### Pre-requisite
+1. Minimum k8s version - 1.21+
+2. Installation of csi drivers through helm chart or with kubectl commands. ref: https://github.com/kubernetes-sigs/azurefile-csi-driver#install-driver-on-a-kubernetes-cluster
+
+
+
+### Install driver on a Kubernetes cluster
+
 1. Create [`azure.json`](./azure.json) cloud config file and fill in all necessary fields, refer to [cloud provider config](https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs/).
 - Make sure identity/service principal used by driver has `Contributor` role in the resource group
 2. Serialize `azure.json` by following command:
@@ -75,16 +83,14 @@ type: Opaque
 kubectl create -f azure-cloud-provider.yaml
 ```
 
-### Install driver on a Kubernetes cluster
-
 - install via [kubectl](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/install-azurefile-csi-driver.md) on public Azure (please use helm for Azure Stack, RedHat/CentOS)
 - install via [helm charts](https://github.com/kubernetes-sigs/azurefile-csi-driver/tree/master/charts) on public Azure, Azure Stack, RedHat/CentOS
 
-### Create storage class
+### Create storage class 
 
-1. Create storage class yaml file [`azurefile-storage-class.yaml`](./azurefile-storage-class.yaml) with provisioner as ```disk.csi.azure.com```
+1. Create storage class yaml file [`azurefile-csi-storage-class.yaml`](./azurefile-csi-storage-class.yaml) with provisioner as ```file.csi.azure.com```
 2. Following command will deploy the storageclass
-``` kubectl apply -f azurefile-storage-class.yaml```
+``` kubectl apply -f azurefile-csi-storage-class.yaml```
 
 
 

--- a/K8s-deployment/K8s-cluster/addons/storage/azure/README.md
+++ b/K8s-deployment/K8s-cluster/addons/storage/azure/README.md
@@ -43,13 +43,55 @@ kubectl create -f azure-cloud-provider.yaml
 ``` kubectl apply -f azuredisk-storage-class.yaml```
 
 # Deployment with AzureFile
-1. Create a storage account on azure for the shared file system. Follow the documentation [here](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal).
-2. Update the `azurefile-storageclass.yaml` with the created storage account name.
-3. Following command will deploy the storageclass
+For in-tree azuredisk drivers, ```kubernetes.io/azure-file``` provisioner can be used in the [azurefile-storage-class.yaml](./azurefile-storage-class.yaml).
+1. Following command will deploy the storageclass
 ``` kubectl apply -f azurefile-storage-class.yaml```
 
-## Links
+## Deployment with AzureDisk csi drivers
+### Prerequisite
+1. Create [`azure.json`](./azure.json) cloud config file and fill in all necessary fields, refer to [cloud provider config](https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs/).
+- Make sure identity/service principal used by driver has `Contributor` role in the resource group
+2. Serialize `azure.json` by following command:
 
+```console
+cat azure.json | base64 | awk '{printf $0}'; echo
+```
+3. Create a secret file [`azure-cloud-provider.yaml`](./azure-cloud-provider.yaml) with following values and fill in `cloud-config` value produced in step#2
+
+```yaml
+apiVersion: v1
+data:
+  cloud-config: [fill-in-here]
+kind: Secret
+metadata:
+  name: azure-cloud-provider
+  namespace: kube-system
+type: Opaque
+```
+
+4. Create a `azure-cloud-provider` secret in k8s cluster
+
+```console
+kubectl create -f azure-cloud-provider.yaml
+```
+
+### Install driver on a Kubernetes cluster
+
+- install via [kubectl](https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/install-azurefile-csi-driver.md) on public Azure (please use helm for Azure Stack, RedHat/CentOS)
+- install via [helm charts](https://github.com/kubernetes-sigs/azurefile-csi-driver/tree/master/charts) on public Azure, Azure Stack, RedHat/CentOS
+
+### Create storage class
+
+1. Create storage class yaml file [`azurefile-storage-class.yaml`](./azurefile-storage-class.yaml) with provisioner as ```disk.csi.azure.com```
+2. Following command will deploy the storageclass
+``` kubectl apply -f azurefile-storage-class.yaml```
+
+
+
+
+
+## Links
+- https://github.com/kubernetes-sigs/azurefile-csi-driver
 - https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/README.md
 - https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
 - https://kubernetes-csi.github.io/docs/

--- a/K8s-deployment/K8s-cluster/addons/storage/azure/azurefile-storage-class.yaml
+++ b/K8s-deployment/K8s-cluster/addons/storage/azure/azurefile-storage-class.yaml
@@ -2,17 +2,24 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: azurefile-storage-class
-provisioner: kubernetes.io/azure-file
+provisioner: file.csi.azure.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 mountOptions:
   - dir_mode=0700
   - file_mode=0700
   - uid=1001
   - gid=1001
+  - mfsymlinks
+  - cache=strict
+  - nosharesock
+  - actimeo=30
 parameters:
   skuName: Standard_LRS
   location: centralindia
-  storageAccount: <storage-account-name>
-
+  storageAccount: k8sazurefile
+  
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Updated Rancher Version to 2.6.9
Changes as per K8s v1.24
1. Updated HPA to autoscale/v2
2. Updated Cron to batch/v2
3. File Storage to csi

