### PR TITLE
4.5.0 post release fixes II

### DIFF
--- a/Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/resource-server/rs-stack.yaml
@@ -22,9 +22,10 @@ services:
         target: /usr/share/app/storage/temp-dir
         volume:
           nocopy: false
-      - type: tmpfs
-        target: /tmp/
-        read_only: false  
+      - type: volume
+        target: /tmp
+        volume:
+          nocopy: false
     logging:
       driver: "json-file"
       options:

--- a/K8s-deployment/Charts/resource-server/values.yaml
+++ b/K8s-deployment/Charts/resource-server/values.yaml
@@ -1226,7 +1226,7 @@ encryption:
         secretName: rs-config
     - name: rs-tmp
       emptyDir:
-        medium: Memory
+        medium: ""
   ## @param encryption.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the encryption container(s)
   ##
   extraVolumeMounts: 


### PR DESCRIPTION
- Fix: unable to deploy encryption verticle in docker swarm
  - Error log while encyrption verticle deployment -
    ``java.lang.NoClassDefFoundError: Could not initialize class
  com.sun.jna.Native``
  - Happened because of use of tmpfs
     - libsodium libraries fail to load in Docker when --tmpfs /tmp
       due to "noexec"  flag on /tmp see:
       1. https://github.com/netty/netty-tcnative/issues/264
       2. https://github.com/moby/moby/issues/18853
   - use unnamed docker volume instead of tmpfs
     
 -  in rs k8s encryption, use ssd based emptydir and  decrease memory consumption, fixed @shreelakshmijoshi 