### PR TITLE
Migrate CA registry from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/K8s-deployment/K8s-cluster/addons/cluster-autoscaler/aws/cluster-autoscaler-autodiscover.yaml
+++ b/K8s-deployment/K8s-cluster/addons/cluster-autoscaler/aws/cluster-autoscaler-autodiscover.yaml
@@ -149,7 +149,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/controlplane: "true"
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.20.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/K8s-deployment/K8s-cluster/addons/cluster-autoscaler/azure/cluster-autoscaler-autodiscover.yaml
+++ b/K8s-deployment/K8s-cluster/addons/cluster-autoscaler/azure/cluster-autoscaler-autodiscover.yaml
@@ -163,7 +163,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/controlplane: "true"
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.24.0
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0
           imagePullPolicy: Always
           name: cluster-autoscaler
           resources:

--- a/K8s-deployment/K8s-cluster/addons/cluster-autoscaler/rancher/values.yaml
+++ b/K8s-deployment/K8s-cluster/addons/cluster-autoscaler/rancher/values.yaml
@@ -232,7 +232,7 @@ fullnameOverride: ""
 
 image:
   # image.repository -- Image repository
-  repository: k8s.gcr.io/autoscaling/cluster-autoscaler
+  repository: registry.k8s.io/autoscaling/cluster-autoscaler
   # image.tag -- Image tag
   tag: v1.26.1
   # image.pullPolicy -- Image pull policy


### PR DESCRIPTION
`k8s.gcr.io` [Image Registry was frozen](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) from the 3rd of April 2023. Of all the IUDX components/add-ons, only the cluster autoscaler was [found](https://kubernetes.io/blog/2023/03/10/image-registry-redirect/#how-can-i-find-which-images-are-using-the-legacy-registry-and-fix-them) to be using its image from the `k8s.gcr.io` registry. 
- Updated CA image registry to `registry.k8s.io`

