### PR TITLE
[Docker-swarm] Mon-stack Software Updates

### DIFF
--- a/Docker-Swarm-deployment/single-node/monitoring-stack/mon-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/monitoring-stack/mon-stack.yaml
@@ -30,7 +30,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   prometheus:
-    image: prom/prometheus:v2.44.0
+    image: prom/prometheus:v2.48.1
     read_only: true
     volumes:
       - type: volume
@@ -67,7 +67,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
  
   loki:
-    image: grafana/loki:2.8.2
+    image: grafana/loki:2.9.3
     read_only: true
     #transfer of logs to loki over overlay
     volumes:
@@ -104,7 +104,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   grafana:
-    image: ghcr.io/datakaveri/grafana:9.5.2
+    image: ghcr.io/datakaveri/grafana:10.2.3
     read_only: true
     volumes:
       - type: volume
@@ -153,7 +153,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   promtail:
-    image: grafana/promtail:2.8.2
+    image: grafana/promtail:2.9.3
     read_only: true
     entrypoint: /run.sh
     user: root
@@ -285,4 +285,3 @@ secrets:
     file: secrets/passwords/grafana-super-admin-username
   blackbox-targets:
     file: secrets/configs/blackbox-targets.yaml
-  


### PR DESCRIPTION
This PR updates the components of the Mon-stack as follows:

    Prometheus: Image version updated from v2.44.0 to v2.48.1.
    Loki: Image version updated from 2.8.2 to 2.9.3.
    Grafana: Image version updated from 9.5.2 to 10.2.3.
    Promtail: Image version updated from 2.8.2 to 2.9.3.
    Added mon-stack.yaml file with the latest image versions.