### PR TITLE
[Docker/K8s] postgres init-script changes for 5.5.0

### DIFF
--- a/Docker-Swarm-deployment/single-node/postgres/create-secrets.sh
+++ b/Docker-Swarm-deployment/single-node/postgres/create-secrets.sh
@@ -8,4 +8,6 @@ echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwor
 echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-auth-password
 echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-rs-password
 echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-keycloak-password
+echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-acl-apd-password
+echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-dmp-apd-password
 

--- a/Docker-Swarm-deployment/single-node/postgres/init-scripts/db-user-creation.sh
+++ b/Docker-Swarm-deployment/single-node/postgres/init-scripts/db-user-creation.sh
@@ -12,6 +12,16 @@ auth_username=iudx_auth_user
 auth_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-auth-password)
 ##auth server uses default postgres db
 
+##acl-apd
+acl_apd_username=iudx_acl_apd_user
+acl_apd_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-acl-apd-password)
+acl_apd_db_name=iudx_acl_apd
+
+## dmp-apd
+dmp_apd_username=iudx_dmp_apd_user
+dmp_apd_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-dmp-apd-password)
+dmp_apd_db_name=iudx_dmp_apd
+
 PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
 CREATE DATABASE $rs_db_name WITH ENCODING 'UTF8';
 CREATE ROLE $rs_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
@@ -27,4 +37,18 @@ ALTER DATABASE $keycloak_db_name OWNER TO $keycloak_username;
 
 CREATE ROLE $auth_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
 ALTER ROLE $auth_username WITH  ENCRYPTED PASSWORD '$auth_passwd';
+EOSQL
+
+PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER"  <<-EOSQL
+CREATE ROLE $acl_apd_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
+ALTER ROLE $acl_apd_username WITH  ENCRYPTED PASSWORD '$acl_apd_passwd';
+CREATE DATABASE $acl_apd_db_name WITH ENCODING 'UTF8';
+ALTER DATABASE $acl_apd_db_name OWNER TO $acl_apd_username;
+EOSQL
+
+PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER"  <<-EOSQL
+CREATE ROLE $dmp_apd_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
+ALTER ROLE $dmp_apd_username WITH  ENCRYPTED PASSWORD '$dmp_apd_passwd';
+CREATE DATABASE $dmp_apd_db_name WITH ENCODING 'UTF8';
+ALTER DATABASE $dmp_apd_db_name OWNER TO $dmp_apd_username;
 EOSQL

--- a/K8s-deployment/Charts/postgresql/create-secrets.sh
+++ b/K8s-deployment/Charts/postgresql/create-secrets.sh
@@ -8,6 +8,8 @@ echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwor
 echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-auth-password
 echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-rs-password
 echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-keycloak-password
-echo -n "postgres;iudx_rs_user;iudx_auth_user;iudx_keycloak_user" > secrets/passwords/usernames
-echo -n "$(cat secrets/passwords/postgresql-password);$(cat secrets/passwords/postgres-rs-password);$(cat secrets/passwords/postgres-auth-password);$(cat secrets/passwords/postgres-keycloak-password)" > secrets/passwords/passwords
+echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-acl-apd-password
+echo -n  $(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 30) > secrets/passwords/postgres-dmp-apd-password
+echo -n "postgres;iudx_rs_user;iudx_auth_user;iudx_keycloak_user;iudx_acl_apd_user;iudx_dmp_apd_user" > secrets/passwords/usernames
+echo -n "$(cat secrets/passwords/postgresql-password);$(cat secrets/passwords/postgres-rs-password);$(cat secrets/passwords/postgres-auth-password);$(cat secrets/passwords/postgres-keycloak-password);$(cat secrets/passwords/postgres-dmp-apd-password);$(cat secrets/passwords/postgres-acl-apd-password)" > secrets/passwords/passwords
 

--- a/K8s-deployment/Charts/postgresql/example-secrets/secrets/passwords/postgres-acl-apd-password
+++ b/K8s-deployment/Charts/postgresql/example-secrets/secrets/passwords/postgres-acl-apd-password
@@ -1,0 +1,1 @@
+iudx-acl-apd

--- a/K8s-deployment/Charts/postgresql/example-secrets/secrets/passwords/postgres-dmp-apd-password
+++ b/K8s-deployment/Charts/postgresql/example-secrets/secrets/passwords/postgres-dmp-apd-password
@@ -1,0 +1,1 @@
+iudx-dmp-apd

--- a/K8s-deployment/Charts/postgresql/init-scripts/db-user-creation.sh
+++ b/K8s-deployment/Charts/postgresql/init-scripts/db-user-creation.sh
@@ -12,6 +12,16 @@ auth_username=iudx_auth_user
 auth_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-auth-password)
 ##auth server uses default postgres db
 
+##acl-apd
+acl_apd_username=iudx_acl_apd_user
+acl_apd_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-acl-apd-password)
+acl_apd_db_name=iudx_acl_apd
+
+## dmp-apd
+dmp_apd_username=iudx_dmp_apd_user
+dmp_apd_passwd=$(cat /opt/bitnami/postgresql/secrets/postgres-dmp-apd-password)
+dmp_apd_db_name=iudx_dmp_apd
+
 PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
 CREATE DATABASE $rs_db_name WITH ENCODING 'UTF8';
 CREATE ROLE $rs_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
@@ -27,4 +37,18 @@ ALTER DATABASE $keycloak_db_name OWNER TO $keycloak_username;
 
 CREATE ROLE $auth_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
 ALTER ROLE $auth_username WITH  ENCRYPTED PASSWORD '$auth_passwd';
+EOSQL
+
+PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER"  <<-EOSQL
+CREATE ROLE $acl_apd_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
+ALTER ROLE $acl_apd_username WITH  ENCRYPTED PASSWORD '$acl_apd_passwd';
+CREATE DATABASE $acl_apd_db_name WITH ENCODING 'UTF8';
+ALTER DATABASE $acl_apd_db_name OWNER TO $acl_apd_username;
+EOSQL
+
+PGPASSWORD=$(cat /opt/bitnami/postgresql/secrets/postgresql-password) psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER"  <<-EOSQL
+CREATE ROLE $dmp_apd_username WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB LOGIN NOREPLICATION NOBYPASSRLS;
+ALTER ROLE $dmp_apd_username WITH  ENCRYPTED PASSWORD '$dmp_apd_passwd';
+CREATE DATABASE $dmp_apd_db_name WITH ENCODING 'UTF8';
+ALTER DATABASE $dmp_apd_db_name OWNER TO $dmp_apd_username;
 EOSQL


### PR DESCRIPTION
added acl-apd and dmp-apd as seperate user and  database in postgres init-script for both K8s and Docker deployment.