### PR TITLE
Added modified Bitnami PostgreSQL 16 Dockerfile for GDI foreign data wrappers

### DIFF
--- a/docker/postgres/modded-postgresql.Dockerfile
+++ b/docker/postgres/modded-postgresql.Dockerfile
@@ -1,0 +1,43 @@
+ARG VERSION="0.0.1-SNAPSHOT"
+
+# Using minideb:bullseye to build the required packages since it's what bitnami images are based off
+FROM bitnami/minideb:bullseye as builder
+
+WORKDIR /tmp/build
+
+# install postgres-common packages to add the postgres PPA so that we can install the postgres-server-dev-16 packages
+RUN apt update && apt install -y --no-install-recommends gnupg2 postgresql-common && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v 16
+
+# install all required packages to build the multicorn and OGR extension 
+RUN apt install -y --no-install-recommends build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc postgresql-server-dev-16 python3 python3-dev python3-setuptools python3-pip wget libgdal-dev
+
+# fetch the multicorn code, uncompress and build
+RUN wget https://github.com/pgsql-io/multicorn2/archive/refs/tags/v3.0.tar.gz && tar -xvf v3.0.tar.gz && cd multicorn2-3.0 && make
+
+# fetch the OGR code, uncompress and build
+RUN wget https://github.com/pramsey/pgsql-ogr-fdw/archive/refs/tags/v1.1.5.tar.gz && tar -xvf v1.1.5.tar.gz && cd pgsql-ogr-fdw-1.1.5 && make
+
+# fetch the GDI Python scripts and uncompress
+RUN cd /tmp/build && wget https://github.com/datakaveri/gdi-multicorn-scripts/archive/refs/heads/main.tar.gz && tar -xvf main.tar.gz 
+
+FROM bitnami/postgresql:16.1.0
+USER root
+
+# copy APT cache and lists from builder so that packages already downloaded need not be downloaded again (only installed)
+COPY --from=builder /var/cache/apt/ /var/cache/apt/
+COPY --from=builder /var/lib/apt/lists/ /var/lib/apt/lists/
+
+# copy the built OGR extension, install libgdal-dev and then run make install to install the extension into the final container.
+COPY --from=builder /tmp/build/pgsql-ogr-fdw-1.1.5 /pgsql-ogr-fdw-1.1.5
+RUN apt install -y make libgdal-dev --no-install-recommends && cd /pgsql-ogr-fdw-1.1.5 && make install
+
+# copy the built multicorn extension, install python and then run make install to install the extension into the final container.
+COPY --from=builder /tmp/build/multicorn2-3.0 /multicorn2-3.0
+RUN apt install -y python3 python3-dev python3-pip gcc --no-install-recommends && cd /multicorn2-3.0 && make install && rm -rf /var/lib/apt/lists/* && apt remove -y gcc make && apt autoremove -y && apt clean -y
+
+# copy the GSX/GDI Python scripts and install them to the global Python install using pip
+COPY --from=builder /tmp/build/gdi-multicorn-scripts-main /gdi-multicorn-scripts-main
+RUN cd /gdi-multicorn-scripts-main && pip install .
+
+# drop down to the low-priv user that the original bitnami:postgresql image uses
+USER 1001

--- a/docker/postgres/modded-postgresql.Dockerfile
+++ b/docker/postgres/modded-postgresql.Dockerfile
@@ -23,13 +23,9 @@ RUN cd /tmp/build && wget https://github.com/datakaveri/gdi-multicorn-scripts/ar
 FROM bitnami/postgresql:16.1.0
 USER root
 
-# copy APT cache and lists from builder so that packages already downloaded need not be downloaded again (only installed)
-COPY --from=builder /var/cache/apt/ /var/cache/apt/
-COPY --from=builder /var/lib/apt/lists/ /var/lib/apt/lists/
-
-# copy the built OGR extension, install libgdal-dev and then run make install to install the extension into the final container.
+# copy the built OGR extension, install gdal-bin and then run make install to install the extension into the final container.
 COPY --from=builder /tmp/build/pgsql-ogr-fdw-1.1.5 /pgsql-ogr-fdw-1.1.5
-RUN apt install -y make libgdal-dev --no-install-recommends && cd /pgsql-ogr-fdw-1.1.5 && make install
+RUN apt update && apt install -y make gdal-bin --no-install-recommends && cd /pgsql-ogr-fdw-1.1.5 && make install
 
 # copy the built multicorn extension, install python and then run make install to install the extension into the final container.
 COPY --from=builder /tmp/build/multicorn2-3.0 /multicorn2-3.0

--- a/docker/postgres/modded-postgresql.Dockerfile
+++ b/docker/postgres/modded-postgresql.Dockerfile
@@ -1,37 +1,76 @@
 ARG VERSION="0.0.1-SNAPSHOT"
 
-# Using minideb:bullseye to build the required packages since it's what bitnami images are based off
+# Build stage for extensions
 FROM bitnami/minideb:bullseye as builder
 
 WORKDIR /tmp/build
 
-# install postgres-common packages to add the postgres PPA so that we can install the postgres-server-dev-16 packages
-RUN apt update && apt install -y --no-install-recommends gnupg2 postgresql-common && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v 16
+# Install all dependencies in a single layer for better cache utilization
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gnupg2 \
+    postgresql-common \
+    build-essential \
+    libreadline-dev \
+    zlib1g-dev \
+    flex \
+    bison \
+    libxml2-dev \
+    libxslt-dev \
+    libssl-dev \
+    libxml2-utils \
+    xsltproc \
+    python3 \
+    python3-dev \
+    python3-setuptools \
+    python3-pip \
+    libgdal-dev && \
+    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v 16 && \
+    apt-get install -y --no-install-recommends postgresql-server-dev-16
 
-# install all required packages to build the multicorn and OGR extension 
-RUN apt install -y --no-install-recommends build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc postgresql-server-dev-16 python3 python3-dev python3-setuptools python3-pip wget libgdal-dev
+# Fetch the multicorn and OGR code
+ADD --chmod=644 https://github.com/pgsql-io/multicorn2/archive/refs/tags/v3.0.tar.gz /tmp/build/multicorn.tar.gz
+ADD --chmod=644 https://github.com/pramsey/pgsql-ogr-fdw/archive/refs/tags/v1.1.5.tar.gz /tmp/build/ogr.tar.gz
 
-# fetch the multicorn code, uncompress and build
-RUN wget https://github.com/pgsql-io/multicorn2/archive/refs/tags/v3.0.tar.gz && tar -xvf v3.0.tar.gz && cd multicorn2-3.0 && make
+# Build multicorn and OGR extensions
+RUN tar -xf multicorn.tar.gz && \
+    cd multicorn2-3.0 && \
+    make && \
+    cd .. && \
+    tar -xf ogr.tar.gz && \
+    cd pgsql-ogr-fdw-1.1.5 && \
+    make
 
-# fetch the OGR code, uncompress and build
-RUN wget https://github.com/pramsey/pgsql-ogr-fdw/archive/refs/tags/v1.1.5.tar.gz && tar -xvf v1.1.5.tar.gz && cd pgsql-ogr-fdw-1.1.5 && make
-
+# Final stage
 FROM bitnami/postgresql:16.1.0
+
 USER root
 
-# copy the built OGR extension, install gdal-bin and then run make install to install the extension into the final container.
+# Copy Built Extensions
 COPY --from=builder /tmp/build/pgsql-ogr-fdw-1.1.5 /pgsql-ogr-fdw-1.1.5
-RUN apt update && apt install -y make gdal-bin --no-install-recommends && cd /pgsql-ogr-fdw-1.1.5 && make install
-
-# copy the built multicorn extension, install python and then run make install to install the extension into the final container.
 COPY --from=builder /tmp/build/multicorn2-3.0 /multicorn2-3.0
-RUN apt install -y python3 python3-dev python3-pip gcc --no-install-recommends && cd /multicorn2-3.0 && make install && rm -rf /var/lib/apt/lists/* && apt remove -y gcc make && apt autoremove -y && apt clean -y
 
-# fetch Multicorn scripts and install them to the global Python instance using pip
-# using ADD so that this layer will be rebuilt when the code in HEAD of main branch changes
+# Install dependencies and extensions and clean up.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    gdal-bin \
+    python3 \
+    python3-dev \
+    python3-pip \
+    make \
+    gcc && \
+    cd /pgsql-ogr-fdw-1.1.5 && \
+    make install && \
+    cd /multicorn2-3.0 && \
+    make install && \
+    rm -rf /pgsql-ogr-fdw-1.1.5 /multicorn2-3.0 && \
+    apt-get remove -y gcc make && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Fetch and Install multicorn scripts
 ADD https://github.com/datakaveri/gdi-multicorn-scripts/archive/refs/heads/main.tar.gz /scripts.tar.gz
-RUN pip install --no-cache-dir scripts.tar.gz && rm scripts.tar.gz
+RUN pip install --no-cache-dir /scripts.tar.gz && rm scripts.tar.gz
 
-# drop down to the low-priv user that the original bitnami:postgresql image uses
 USER 1001


### PR DESCRIPTION
- Modded the Bitnami PostgreSQL 16 Dockerfile to install
    - Multicorn PostgreSQL extension, which requires - Python3
    - OGR Foreign Data Wrapper PostgreSQL extension, which requires
        - GDAL 
    - Python scripts + dependencies for the Multicorn extension, available at https://github.com/datakaveri/gdi-multicorn-scripts
- Image size is around 1.11GB