### PR TITLE
updated keycloak to 26.2.3 with proper configs

### DIFF
--- a/Docker-Swarm-deployment/single-node/keycloak/keycloak-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/keycloak/keycloak-stack.yaml
@@ -8,7 +8,7 @@ networks:
 
 services:
   keycloak:
-    image: ghcr.io/datakaveri/keycloak:23.0.4-IAUSDX-themes-1.1
+    image: ghcr.io/datakaveri/keycloak:26.2.3-iausdx-themes-2.6
     cap_drop:
        - ALL
 
@@ -44,10 +44,11 @@ services:
       - KEYCLOAK_DATABASE_PORT=5432
       - KEYCLOAK_DATABASE_USER=iudx_keycloak_user
       - KEYCLOAK_DATABASE_PASSWORD_FILE=/opt/bitnami/keycloak/secrets/keycloak-db-passwd
-      - KEYCLOAK_HTTP_RELATIVE_PATH=/auth 
+      - KEYCLOAK_HTTP_RELATIVE_PATH=/auth
       - KEYCLOAK_PRODUCTION=TRUE # running in production mode, https://www.keycloak.org/server/configuration#_configuring_the_server_by_using_configuration_files
-      - KEYCLOAK_PROXY=edge # proxy edge mode, allow http comm between proxy and keycloak, https://www.keycloak.org/server/reverseproxy#_proxy_modes
+      - KEYCLOAK_PROXY_HEADERS=xforwarded # Keycloak reverse proxy headers https://github.com/bitnami/containers/blob/main/bitnami/keycloak/README.md
       - KEYCLOAK_LOG_OUTPUT=json # structured logs, easier to parse and do queries in grafana/loki
+
 
 secrets:
   keycloak-db-passwd:

--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -1,2 +1,2 @@
-FROM bitnami/keycloak:23.0.4-debian-11-r1
+FROM bitnami/keycloak:26.2.3-debian-12-r0
 COPY src/ /opt/bitnami/keycloak/themes/


### PR DESCRIPTION
Only the necessary configs are included in the commit from, [here](https://github.com/bitnami/containers/commits/main/bitnami/keycloak/README.md)

#### Config Changelog 

23.0.7-debian-r4
KEYCLOAK_JDBC_DRIVER=postgres

24.0.3-debian12-r0
KC_RUN_IN_CONTAINER

24.0.3-debian12-r2
KEYCLOAK_CACHE_CONFIG_FILE

24.0.5-debian-12-r1 = No config change

24.0.5-debian-12-r3
KEYCLOAK_PROXY=edge ==> KEYCLOAK_PROXY_HEADERS=xforwarded

KEYCLOAK_HOSTNAME_ADMIN=
KEYCLOAK_HOSTNAME_STRICT=

25.0.6 - No config changes
26.0.7 - No config changes