### PR TITLE
[Docker-swarm] Mon-stack Software Updates

### DIFF
--- a/Docker-Swarm-deployment/single-node/infrastructure/files/node-exporter-manager.sh
+++ b/Docker-Swarm-deployment/single-node/infrastructure/files/node-exporter-manager.sh
@@ -29,14 +29,14 @@ while getopts ":a:" opt; do
 	esac
 done
 
-release="https://github.com/prometheus/node_exporter/releases/download/v1.4.0/node_exporter-1.4.0.linux-amd64.tar.gz"
+release="https://github.com/prometheus/node_exporter/releases/download/v1.9.1/node_exporter-1.9.1.linux-amd64.tar.gz"
 bin_dst="/usr/local/bin"
 bin="node_exporter"
 service_path="/etc/systemd/system/$bin.service"
 
 if [[ $action == "install" ]]; then
 	curl -L -s $release --output ne.tar.gz
-	tar -xzvf ne.tar.gz -C $bin_dst "node_exporter-1.4.0.linux-amd64/$bin" --strip-components 1
+	tar -xzvf ne.tar.gz -C $bin_dst "node_exporter-1.9.1.linux-amd64/$bin" --strip-components 1
 	rm ne.tar.gz
 
 	cat > $service_path <<EOF

--- a/Docker-Swarm-deployment/single-node/monitoring-stack/loki/conf/loki-config.yaml
+++ b/Docker-Swarm-deployment/single-node/monitoring-stack/loki/conf/loki-config.yaml
@@ -12,54 +12,37 @@ ingester:
       replication_factor: 1
     final_sleep: 0s
 
-  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
-  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
-  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached
+  chunk_idle_period: 1h
+  max_chunk_age: 1h
+  chunk_target_size: 1048576
   chunk_retain_period: 30s
-  max_transfer_retries: 0
 
 schema_config:
   configs:
-    - from: 2018-04-15
-      store: boltdb
+    - from: 2025-04-01
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
-        period: 168h
-
-    - from: 2020-11-05
-      store: boltdb-shipper
-      object_store: filesystem   
-      schema: v11
-      index:
-        prefix: newindex_
-        period: 24h   
+        period: 24h
 
 storage_config:
-  boltdb:
-    directory: /data/loki/index
-
-  boltdb_shipper:
-    active_index_directory: /data/loki/boltdb-shipper-active
-    cache_location: /data/loki/boltdb-shipper-cache
-    shared_store: filesystem
+  tsdb_shipper:
+    active_index_directory: /data/loki/tsdb-shipper-active
+    cache_location: /data/loki/tsdb-shipper-cache
     cache_ttl: 24h
 
   filesystem:
     directory: /data/loki/chunks
 
 compactor:
-  working_directory: /data/loki/boltdb-shipper-compactor
-  shared_store: filesystem
+  working_directory: /data/loki/tsdb-shipper-compactor
 
 limits_config:
-  enforce_metric_name: false
+  allow_structured_metadata: false
   reject_old_samples: true
   reject_old_samples_max_age: 168h
-
-chunk_store_config:
-  max_look_back_period: 0s
 
 table_manager:
   retention_deletes_enabled: false

--- a/Docker-Swarm-deployment/single-node/monitoring-stack/mon-stack.yaml
+++ b/Docker-Swarm-deployment/single-node/monitoring-stack/mon-stack.yaml
@@ -30,7 +30,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   prometheus:
-    image: prom/prometheus:v2.48.1
+    image: prom/prometheus:v3.2.1
     read_only: true
     volumes:
       - type: volume
@@ -67,7 +67,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
  
   loki:
-    image: grafana/loki:2.9.3
+    image: grafana/loki:3.4.3
     read_only: true
     #transfer of logs to loki over overlay
     volumes:
@@ -104,7 +104,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   grafana:
-    image: ghcr.io/datakaveri/grafana:10.2.3
+    image: ghcr.io/datakaveri/grafana:11.6.0
     read_only: true
     volumes:
       - type: volume
@@ -153,7 +153,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   promtail:
-    image: grafana/promtail:2.9.3
+    image: grafana/promtail:3.4.3
     read_only: true
     entrypoint: /run.sh
     user: root
@@ -189,7 +189,7 @@ services:
         tag: "{\"name\":\"{{.Name}}\",\"id\":\"{{.ID}}\"}"
 
   blackbox:
-    image: prom/blackbox-exporter:v0.24.0
+    image: prom/blackbox-exporter:v0.26.0
     read_only: true
     deploy:
       placement:
@@ -285,4 +285,4 @@ secrets:
     file: secrets/passwords/grafana-super-admin-username
   blackbox-targets:
     file: secrets/configs/blackbox-targets.yaml
-  
+

--- a/docker/mon-stack/grafana/README.md
+++ b/docker/mon-stack/grafana/README.md
@@ -1,7 +1,7 @@
 # Grafana Installation
 ## Building Docker image
 ```sh
-docker build -t ghcr.io/datakaveri/grafana:10.2.3 --build-arg grafana_version=10.2.3 .
+docker build -t ghcr.io/datakaveri/grafana:11.6.0 --build-arg grafana_version=11.6.0 .
 ```
 ## Description
 conf directory consists of two types of configs:


### PR DESCRIPTION
This pull request includes the following changes: 
-  **Grafana:** Updated image version from `10.2.3` to `11.6.0`
- **Prometheus:** Updated image version from `v2.48.1` to `3.2.1`
- **Loki:** Updated image version from `2.9.3` to `3.4.3`
- **Promtail:** Updated image version from `2.9.3` to `3.4.3`
- **Blackbox exporter:** Updated image version from `v0.24.0` to `v0.26.0`
- **Node exporter:** Updated image version from `1.4.0` to `1.9.1`

- Updated mon-stack.yaml file with the latest versions
- Updated README.md (docker/mon-stack/grafana)
- Updated loki-config.yaml file
- Updated node-exporter-manager.sh file (infrastructure/files)