### PR TITLE
Add Kubernetes manifests for osTicket deployment

### DIFF
--- a/K8s-deployment/Charts/os-ticket/example-osticket-secrets.yaml
+++ b/K8s-deployment/Charts/os-ticket/example-osticket-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+type: Opaque
+stringData: 
+  MYSQL_ROOT_PASSWORD: "your-root-password-here"
+  MYSQL_PASSWORD: "your-user-password-here" 

--- a/K8s-deployment/Charts/os-ticket/install-k8s-manifests.sh
+++ b/K8s-deployment/Charts/os-ticket/install-k8s-manifests.sh
@@ -1,4 +1,5 @@
-kubectl apply -f osticket-pvc.yaml
+kubectl apply -f osticket-secrets.yaml
 kubectl apply -f osticket-configmap.yaml
+kubectl apply -f osticket-pvc.yaml
 kubectl apply -f osticket-mysql.yaml
 kubectl apply -f osticket-web.yaml

--- a/K8s-deployment/Charts/os-ticket/install-k8s-manifests.sh
+++ b/K8s-deployment/Charts/os-ticket/install-k8s-manifests.sh
@@ -1,0 +1,4 @@
+kubectl apply -f osticket-pvc.yaml
+kubectl apply -f osticket-configmap.yaml
+kubectl apply -f osticket-mysql.yaml
+kubectl apply -f osticket-web.yaml

--- a/K8s-deployment/Charts/os-ticket/osticket-configmap.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osticket-config
+data:
+  MYSQL_HOST: "osticket-mysql"
+  MYSQL_USER: "osticket"
+  MYSQL_PASSWORD: "<REPLACE_WITH_SECURE_PASSWORD>"
+  MYSQL_DATABASE: "osticket"

--- a/K8s-deployment/Charts/os-ticket/osticket-configmap.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-configmap.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: osticket-config
+  name: mysql-config
 data:
-  MYSQL_HOST: "osticket-mysql"
-  MYSQL_USER: "osticket"
-  MYSQL_PASSWORD: "<REPLACE_WITH_SECURE_PASSWORD>"
-  MYSQL_DATABASE: "osticket"
+  MYSQL_DATABASE: osticket
+  MYSQL_USER: osticket

--- a/K8s-deployment/Charts/os-ticket/osticket-mysql.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-mysql.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: osticket-mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: osticket-mysql
+  template:
+    metadata:
+      labels:
+        app: osticket-mysql
+    spec:
+      containers:
+      - name: mysql
+        image: mysql:5.7
+        ports:
+        - containerPort: 3306
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_DATABASE
+        - name: MYSQL_USER
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_USER
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_PASSWORD
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-data
+        persistentVolumeClaim:
+          claimName: osticket-db-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: osticket-mysql
+spec:
+  selector:
+    app: osticket-mysql
+  ports:
+  - port: 3306
+    targetPort: 3306
+  clusterIP: None 

--- a/K8s-deployment/Charts/os-ticket/osticket-mysql.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-mysql.yaml
@@ -1,8 +1,9 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: osticket-mysql
 spec:
+  serviceName: osticket-mysql
   replicas: 1
   selector:
     matchLabels:
@@ -20,31 +21,36 @@ spec:
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
-            configMapKeyRef:
-              name: osticket-config
+            secretKeyRef:
+              name: mysql-secret
               key: MYSQL_ROOT_PASSWORD
         - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: osticket-config
+              name: mysql-config
               key: MYSQL_DATABASE
         - name: MYSQL_USER
           valueFrom:
             configMapKeyRef:
-              name: osticket-config
+              name: mysql-config
               key: MYSQL_USER
         - name: MYSQL_PASSWORD
           valueFrom:
-            configMapKeyRef:
-              name: osticket-config
+            secretKeyRef:
+              name: mysql-secret
               key: MYSQL_PASSWORD
         volumeMounts:
         - name: mysql-data
           mountPath: /var/lib/mysql
-      volumes:
-      - name: mysql-data
-        persistentVolumeClaim:
-          claimName: osticket-db-data
+  volumeClaimTemplates:
+  - metadata:
+      name: mysql-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "standard"
+      resources:
+        requests:
+          storage: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/K8s-deployment/Charts/os-ticket/osticket-pvc.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-pvc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: osticket-db-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: osticket-uploads
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: osticket-config
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi 

--- a/K8s-deployment/Charts/os-ticket/osticket-pvc.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-pvc.yaml
@@ -1,21 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: osticket-db-data
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
   name: osticket-uploads
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi
@@ -27,6 +17,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi 

--- a/K8s-deployment/Charts/os-ticket/osticket-web.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-web.yaml
@@ -61,5 +61,25 @@ spec:
   ports:
   - port: 80
     targetPort: 80
-    nodePort: 30080
-  type: NodePort 
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: osticket-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    # Add these annotations for local development
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - http:  # Remove host-based routing for local development
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: osticket-web
+            port:
+              number: 80 

--- a/K8s-deployment/Charts/os-ticket/osticket-web.yaml
+++ b/K8s-deployment/Charts/os-ticket/osticket-web.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: osticket-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: osticket-web
+  template:
+    metadata:
+      labels:
+        app: osticket-web
+    spec:
+      containers:
+      - name: osticket
+        image: ghcr.io/datakaveri/os-ticket:1.0.1
+        ports:
+        - containerPort: 80
+        env:
+        - name: MYSQL_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_HOST
+        - name: MYSQL_USER
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_USER
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_PASSWORD
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: osticket-config
+              key: MYSQL_DATABASE
+        volumeMounts:
+        - name: uploads
+          mountPath: /var/www/html/upload
+        - name: config
+          mountPath: /var/www/html/include/ost-config
+      volumes:
+      - name: uploads
+        persistentVolumeClaim:
+          claimName: osticket-uploads
+      - name: config
+        persistentVolumeClaim:
+          claimName: osticket-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: osticket-web
+spec:
+  selector:
+    app: osticket-web
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30080
+  type: NodePort 


### PR DESCRIPTION
## Type of Change
Configuration - Adding Kubernetes manifests for osTicket deployment

## Changes Made
This PR adds Kubernetes manifests to deploy osTicket on a Kubernetes cluster. The changes include:

- PersistentVolumeClaims for:
  - MySQL data storage
  - osTicket uploads
  - osTicket configuration
- ConfigMap for environment variables
- MySQL deployment and headless service
- osTicket web application deployment and NodePort service
